### PR TITLE
fixed the 'deploy failure on Railway #11 '  bug

### DIFF
--- a/railway.json
+++ b/railway.json
@@ -7,7 +7,7 @@
     "nixpacksPlan": {
       "phases": {
         "setup": {
-          "nixPkgs": ["ffmpeg"]
+          "nixPkgs": ["...", "ffmpeg"]
         }
       }
     }


### PR DESCRIPTION
According to the official documentation, if "..." is not provided, the Node package will not be installed.

https://nixpacks.com/docs/guides/configuring-builds#install-additional-packages docs